### PR TITLE
Add compile_options in CMakeLists.txt and fix all warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,9 @@ add_executable(ics-linker
     src/resolve.cc
     src/resolve.h
 )
+
+target_compile_options(ics-linker PRIVATE
+    -Wall
+    -Wextra
+    -Werror
+)

--- a/src/main.cc
+++ b/src/main.cc
@@ -92,7 +92,7 @@ void recompileObjects(bool isPIE)
     }
 }
 
-void mergeObjects(int argc, char **argv, const char *filename)
+void mergeObjects(const char *filename)
 {
     int status;
     /* TODO: check linker script */
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
 
     resolveSymbols(allObjects);
     
-    mergeObjects(argc, argv, ldConfig.outName);
+    mergeObjects(ldConfig.outName);
 
     reshapeObjFile(ldConfig.outName);
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -99,8 +99,8 @@ ObjectFile parseObjectFile(int fd, bool modify)
     Elf64_Shdr *shdr = reinterpret_cast<Elf64_Shdr *>((char *)mmapRet + shoff);
     char *shstrtab = (char *)mmapRet + shdr[ehdr->e_shstrndx].sh_offset;
 
-    bool hasSymtab = false, hasStrtab = false;
-    uint64_t symtabSize, symtabOff, strtabSize, strtabOff;
+    // bool hasSymtab = false, hasStrtab = false;
+    uint64_t symtabSize, symtabOff, strtabOff;
     for (int i = 0; i < shnum; i++) {
         const char *secName = shstrtab + shdr[i].sh_name;
         Section &s = o.sections[secName];
@@ -111,7 +111,6 @@ ObjectFile parseObjectFile(int fd, bool modify)
             symtabSize = shdr[i].sh_size;
             symtabOff = shdr[i].sh_offset;
         } else if (strcmp(secName, ".strtab") == 0) {
-            strtabSize = shdr[i].sh_size;
             strtabOff = shdr[i].sh_offset;
         }
     }
@@ -132,7 +131,7 @@ ObjectFile parseObjectFile(int fd, bool modify)
     char *strtab = (char *)mmapRet + strtabOff;
 
     Elf64_Sym *symtab = reinterpret_cast<Elf64_Sym *>((char *)mmapRet + symtabOff);
-    for (int i = 0; i < symtabEntry; i++) {
+    for (uint64_t i = 0; i < symtabEntry; i++) {
         const char *name = strtab + symtab[i].st_name;
         /* note here we must strictly keep all symbols, whether they are `useful' or not
          * this is because later we will access symtab using index
@@ -162,7 +161,7 @@ ObjectFile parseObjectFile(int fd, bool modify)
         auto relaCnt = relaSec.size / sizeof(Elf64_Rela);
         // auto &symtabSec = o.sections[".symtab"];
         // auto symtabStart = reinterpret_cast<Elf64_Sym *>((char *)mmapRet + symtabSec.off);
-        for (int i = 0; i < relaCnt; i++) {
+        for (uint64_t i = 0; i < relaCnt; i++) {
             /* zero initialize */
             RelocEntry re {};
             const auto &sym = o.symbolTable[ELF64_R_SYM(relaStart[i].r_info)];


### PR DESCRIPTION
1. Add `-Wall -Wextra -Werror`  compile options to detect potential issues and treat warnings as errors during the build process.

2. Fix all existing warnings: modify `main.cc` and `util.cc`.